### PR TITLE
Update Conditional Security Group Rules

### DIFF
--- a/groups/ceu-infrastructure/data.tf
+++ b/groups/ceu-infrastructure/data.tf
@@ -51,6 +51,7 @@ data "aws_security_group" "ceu_bep" {
 }
 
 data "aws_security_group" "ceu_frontend" {
+  count = var.environment != "live" ? 1 : 0
   filter {
     name   = "group-name"
     values = ["sgr-ceu-fe-asg*"]

--- a/groups/ceu-infrastructure/rds.tf
+++ b/groups/ceu-infrastructure/rds.tf
@@ -43,7 +43,7 @@ module "ceu_rds_security_group" {
         to_port                  = "1521"
         protocol                 = "tcp"
         description              = "Frontend CEU"
-        source_security_group_id = data.aws_security_group.ceu_frontend.id
+        source_security_group_id = data.aws_security_group.ceu_frontend[0].id
       } if env != "live"
     ]
   )


### PR DESCRIPTION
Updated `ceu_frontend` `aws_security_group` data source to be conditional as it doesn't exist in live and so is blocking.
Updated conditional security group rule in `ceu_rds_security_group` module to use now-indexed data source