### PR TITLE
Converting the vault output to save the web subnets rather than security group as cross account security groups does not work with Transit Gateway yet

### DIFF
--- a/groups/ceu-frontend/README.md
+++ b/groups/ceu-frontend/README.md
@@ -42,12 +42,13 @@ This code will build non production in Heritage Dev and Staging and Live will be
 | [aws_cloudwatch_log_group.ceu_fe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_key_pair.ceu_keypair](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_route53_record.ceu_alb_internal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [vault_generic_secret.asg_security_group](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
+| [vault_generic_secret.asg_web_subnet_cidrs](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_secret) | resource |
 | [aws_acm_certificate.acm_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
 | [aws_ami.ceu_fe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_route53_zone.private_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_security_group.nagios_shared](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_subnet.web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_subnet_ids.application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
 | [aws_subnet_ids.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
 | [aws_subnet_ids.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |

--- a/groups/ceu-frontend/data.tf
+++ b/groups/ceu-frontend/data.tf
@@ -22,6 +22,12 @@ data "aws_subnet_ids" "web" {
   }
 }
 
+data "aws_subnet" "web" {
+  for_each = data.aws_subnet_ids.web.ids
+
+  id = each.value
+}
+
 data "aws_subnet_ids" "data" {
   vpc_id = data.aws_vpc.vpc.id
   filter {

--- a/groups/ceu-frontend/outputs.tf
+++ b/groups/ceu-frontend/outputs.tf
@@ -2,12 +2,10 @@ output "ceu_frontend_address_internal" {
   value = aws_route53_record.ceu_alb_internal.fqdn
 }
 
-resource "vault_generic_secret" "asg_security_group" {
+resource "vault_generic_secret" "asg_web_subnet_cidrs" {
   path = "applications/${var.aws_profile}/${var.application}/ceu-fe-outputs"
 
-  data_json = <<EOT
-{
-  "ceu-frontend-security-group": "${module.ceu_fe_asg_security_group.this_security_group_id}"
-}
-EOT
+  data_json = jsonencode({
+    ceu-frontend-web-subnets-cidrs = [for sub in data.aws_subnet.web : sub.cidr_block]
+  })
 }


### PR DESCRIPTION
Converting the vault output to save the web subnets rather than security group as cross account security groups does not work with Transit Gateway yet