### PR TITLE
Conditionally specify either subnets or subnet_mapping

### DIFF
--- a/groups/ceu-frontend/alb-internal.tf
+++ b/groups/ceu-frontend/alb-internal.tf
@@ -29,7 +29,7 @@ module "ceu_internal_alb" {
   enable_deletion_protection = true
 
   security_groups = [module.ceu_internal_alb_security_group.this_security_group_id]
-  subnets         = data.aws_subnet_ids.web.ids
+  subnets         = var.fe_alb_static_addressing ? [] : data.aws_subnet_ids.web.ids
   subnet_mapping  = local.ceu_fe_alb_subnet_mapping_list
 
   access_logs = {


### PR DESCRIPTION
Updated ALB module to specify an empty `subnets` list if static address is being used and a `subnet_mapping` list is supplied. Both values cannot be populated together.

Partially Resolves: CM-876