### PR TITLE
Add NLB for static IP assignments

### DIFF
--- a/groups/ceu-frontend/alb-internal.tf
+++ b/groups/ceu-frontend/alb-internal.tf
@@ -9,7 +9,8 @@ module "ceu_internal_alb_security_group" {
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = local.internal_cidrs
+  ingress_cidr_blocks = var.fe_nlb_static_addressing ? local.ceu_fe_nlb_cidrs : local.internal_cidrs
+
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
 
   egress_rules = ["all-all"]
@@ -29,8 +30,7 @@ module "ceu_internal_alb" {
   enable_deletion_protection = true
 
   security_groups = [module.ceu_internal_alb_security_group.this_security_group_id]
-  subnets         = var.fe_alb_static_addressing ? [] : data.aws_subnet_ids.web.ids
-  subnet_mapping  = local.ceu_fe_alb_subnet_mapping_list
+  subnets         = data.aws_subnet_ids.web.ids
 
   access_logs = {
     bucket  = local.elb_access_logs_bucket_name

--- a/groups/ceu-frontend/data.tf
+++ b/groups/ceu-frontend/data.tf
@@ -88,10 +88,10 @@ data "vault_generic_secret" "ceu_fe_data" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/frontend"
 }
 
-data "vault_generic_secret" "ceu_fe_alb_subnet_mappings" {
-  count = var.fe_alb_static_addressing ? 1 : 0
+data "vault_generic_secret" "ceu_fe_nlb_subnet_mappings" {
+  count = var.fe_nlb_static_addressing ? 1 : 0
 
-  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/alb_subnet_mappings"
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/nlb_subnet_mappings"
 }
 
 data "aws_acm_certificate" "acm_cert" {

--- a/groups/ceu-frontend/locals.tf
+++ b/groups/ceu-frontend/locals.tf
@@ -39,11 +39,13 @@ locals {
     cw_agent_user              = "root"
   }
 
-  ceu_fe_alb_subnet_mapping_data = var.fe_alb_static_addressing ? data.vault_generic_secret.ceu_fe_alb_subnet_mappings[0].data : {}
-  ceu_fe_alb_subnet_mapping_list = var.fe_alb_static_addressing ? [
+  ceu_fe_nlb_cidrs = var.fe_nlb_static_addressing ? formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_internal : eni.private_ip]) : []
+
+  ceu_fe_nlb_subnet_mapping_data = var.fe_nlb_static_addressing ? data.vault_generic_secret.ceu_fe_nlb_subnet_mappings[0].data : {}
+  ceu_fe_nlb_subnet_mapping_list = var.fe_nlb_static_addressing ? [
     for id in data.aws_subnet_ids.web.ids : {
       subnet_id            = id
-      private_ipv4_address = local.ceu_fe_alb_subnet_mapping_data[id]
+      private_ipv4_address = local.ceu_fe_nlb_subnet_mapping_data[id]
     }
    ] : []
 

--- a/groups/ceu-frontend/locals.tf
+++ b/groups/ceu-frontend/locals.tf
@@ -39,7 +39,7 @@ locals {
     cw_agent_user              = "root"
   }
 
-  ceu_fe_nlb_cidrs = var.fe_nlb_static_addressing ? formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_internal : eni.private_ip]) : []
+  ceu_fe_nlb_cidrs = var.fe_nlb_static_addressing ? formatlist("%s/32", [for eni in data.aws_network_interface.ceu_internal_nlb : eni.private_ip]) : []
 
   ceu_fe_nlb_subnet_mapping_data = var.fe_nlb_static_addressing ? data.vault_generic_secret.ceu_fe_nlb_subnet_mappings[0].data : {}
   ceu_fe_nlb_subnet_mapping_list = var.fe_nlb_static_addressing ? [

--- a/groups/ceu-frontend/nlb_internal.tf
+++ b/groups/ceu-frontend/nlb_internal.tf
@@ -1,0 +1,117 @@
+data "aws_network_interface" "nlb_fe_internal" {
+  for_each = {
+    for key, subnet in data.aws_subnet_ids.web.ids : key => subnet
+    if var.fe_nlb_static_addressing
+  }
+
+  filter {
+    name   = "description"
+    values = ["ELB ${module.nlb_fe_internal[0].this_lb_arn_suffix}"]
+  }
+
+  filter {
+    name   = "subnet-id"
+    values = [each.value]
+  }
+}
+
+module "ceu_internal_nlb_security_group" {
+  count = var.fe_nlb_static_addressing ? 1 : 0
+
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 3.0"
+
+  name        = "sgr-${var.application}-internal-alb-001"
+  description = "Security group for the ${var.application} web servers"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  ingress_cidr_blocks = local.internal_cidrs
+  ingress_rules       = ["http-80-tcp", "https-443-tcp"]
+
+  egress_rules = ["all-all"]
+}
+
+module "nlb_fe_internal" {
+  count = var.fe_nlb_static_addressing ? 1 : 0
+
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 5.0"
+
+  name                       = "nlb-${var.application}-fe-internal-001"
+  vpc_id                     = data.aws_vpc.vpc.id
+  internal                   = true
+  load_balancer_type         = "network"
+  enable_deletion_protection = true
+
+  security_groups = [module.ceu_internal_nlb_security_group[0].this_security_group_id]
+  subnet_mapping  = local.ceu_fe_nlb_subnet_mapping_list
+
+  http_tcp_listeners = [
+    {
+      port               = 80
+      protocol           = "TCP"
+      target_group_index = 0
+    },
+    {
+      port               = 443
+      protocol           = "TCP"
+      target_group_index = 1
+    }
+  ]
+
+  target_groups = [
+    {
+      name                 = "tg-${var.application}-fe-internal-alb-001"
+      backend_protocol     = "TCP"
+      backend_port         = 80
+      target_type          = "alb"
+      targets = [
+        {
+          target_id        = module.ceu_internal_alb.this_lb_arn
+          port             = 80
+        }
+      ]
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "HTTP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+    {
+      name                 = "tg-${var.application}-fe-internal-alb-002"
+      backend_protocol     = "TCP"
+      backend_port         = 443
+      target_type          = "alb"
+      targets = [
+        {
+          target_id        = module.ceu_internal_alb.this_lb_arn
+          port             = 443
+        }
+      ]
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "HTTP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    }
+  ]
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-FE-Support"
+    )
+  )
+}

--- a/groups/ceu-frontend/nlb_internal.tf
+++ b/groups/ceu-frontend/nlb_internal.tf
@@ -1,4 +1,4 @@
-data "aws_network_interface" "nlb_fe_internal" {
+data "aws_network_interface" "ceu_internal_nlb" {
   for_each = {
     for key, subnet in data.aws_subnet_ids.web.ids : key => subnet
     if var.fe_nlb_static_addressing
@@ -6,7 +6,7 @@ data "aws_network_interface" "nlb_fe_internal" {
 
   filter {
     name   = "description"
-    values = ["ELB ${module.nlb_fe_internal[0].this_lb_arn_suffix}"]
+    values = ["ELB ${module.ceu_internal_nlb[0].this_lb_arn_suffix}"]
   }
 
   filter {
@@ -31,7 +31,7 @@ module "ceu_internal_nlb_security_group" {
   egress_rules = ["all-all"]
 }
 
-module "nlb_fe_internal" {
+module "ceu_internal_nlb" {
   count = var.fe_nlb_static_addressing ? 1 : 0
 
   source  = "terraform-aws-modules/alb/aws"

--- a/groups/ceu-frontend/profiles/pci-services-eu-west-2/vars
+++ b/groups/ceu-frontend/profiles/pci-services-eu-west-2/vars
@@ -16,7 +16,7 @@ fe_instance_size = "t2.medium"
 fe_min_size = 1
 fe_max_size = 1
 fe_desired_capacity = 1
-fe_alb_static_addressing = true
+fe_nlb_static_addressing = true
 
 enable_sns_topic = "true"
 

--- a/groups/ceu-frontend/route53.tf
+++ b/groups/ceu-frontend/route53.tf
@@ -4,8 +4,8 @@ resource "aws_route53_record" "ceu_alb_internal" {
   type    = "A"
 
   alias {
-    name                   = module.ceu_internal_alb.this_lb_dns_name
-    zone_id                = module.ceu_internal_alb.this_lb_zone_id
+    name                   = var.fe_nlb_static_addressing ? module.ceu_internal_nlb[0].this_lb_dns_name : module.ceu_internal_alb.this_lb_dns_name
+    zone_id                = var.fe_nlb_static_addressing ? module.ceu_internal_nlb[0].this_lb_zone_id : module.ceu_internal_alb.this_lb_zone_id
     evaluate_target_health = true
   }
 }

--- a/groups/ceu-frontend/variables.tf
+++ b/groups/ceu-frontend/variables.tf
@@ -122,10 +122,10 @@ variable "fe_default_log_group_retention_in_days" {
   description = "Total days to retain logs in CloudWatch log group if not specified for specific logs"
 }
 
-variable "fe_alb_static_addressing" {
+variable "fe_nlb_static_addressing" {
   type        = bool
   default     = false
-  description = "Controls whether to define static IP addressing for the ALB (true) or use default dynamic addressing (false)"
+  description = "Controls whether to define static IP addressing through the use of an NLB (true) or use the default dynamic addressing (false)"
 }
 
 variable "fe_app_release_version" {


### PR DESCRIPTION
Largely reverted previous work on ALB configuration as it's not a supported configuration.
Conditionally define NLB and associated resources to sit in front of the ALB, when static addressing is enabled
Updated ALB SG to only permit ingress from the NLB when static addressing is enabled
Updated Route53 entry to conditionally use the NLB outputs instead of the ALB outputs
Renamed various variables, locals and data sources to reflect their use with an NLB, rather than an ALB

Partially Resolves: CM-876