### PR TITLE
Generalise Oracle 12.1 RDS Engine Versions

### DIFF
--- a/groups/ceu-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -22,7 +22,7 @@ rds_backup_window       = "03:00-06:00"
 
 # RDS Engine settings
 major_engine_version        = "12.1"
-engine_version              = "12.1.0.2.v26"
+engine_version              = "12.1"
 license_model               = "license-included"
 auto_minor_version_upgrade  = true
 

--- a/groups/ceu-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -22,7 +22,7 @@ rds_backup_window       = "03:00-06:00"
 
 # RDS Engine settings
 major_engine_version        = "12.1"
-engine_version              = "12.1.0.2.v26"
+engine_version              = "12.1"
 license_model               = "license-included"
 auto_minor_version_upgrade  = true
 


### PR DESCRIPTION
Generalised Oracle 12.1 RDS engine versions to their major versions to prevent code/state inconsistencies caused when an automatic minor version upgrade is applied.

Versions should only be specified to the minor level when automatic upgrades are not enabled.