### PR TITLE
Add RDS CloudWatch Alarms

### DIFF
--- a/groups/ceu-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -182,3 +182,8 @@ nfs_mounts = {
     local_mount_point = "/mnt/nfs/ceu/post"
   }
 }
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/ceu-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -192,3 +192,8 @@ nfs_mounts = {
     nfs_server_address = "ipo-file-svm-lif-be1.internal.ch"
   }
 }
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = "Email_Alerts"
+alarm_topic_name_ooh   = "Phonecall_Alerts"

--- a/groups/ceu-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -182,3 +182,8 @@ nfs_mounts = {
     local_mount_point = "/mnt/nfs/ceu/post"
   }
 }
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/ceu-infrastructure/rds.tf
+++ b/groups/ceu-infrastructure/rds.tf
@@ -164,3 +164,13 @@ module "rds_start_stop_schedule" {
   rds_start_schedule  = var.rds_start_schedule
   rds_stop_schedule   = var.rds_stop_schedule
 }
+
+module "rds_cloudwatch_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+
+  rds_instance_id        = module.ceu_rds.this_db_instance_id
+  rds_instance_shortname = upper(var.application)
+  alarm_actions_enabled  = var.alarm_actions_enabled
+  alarm_topic_name       = var.alarm_topic_name
+  alarm_topic_name_ooh   = var.alarm_topic_name_ooh
+}

--- a/groups/ceu-infrastructure/variables.tf
+++ b/groups/ceu-infrastructure/variables.tf
@@ -144,6 +144,24 @@ variable "rds_stop_schedule" {
 }
 
 # ------------------------------------------------------------------------------
+# RDS CloudWatch Alarm Variables
+# ------------------------------------------------------------------------------
+variable "alarm_actions_enabled" {
+  type        = string
+  description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
+}
+
+variable "alarm_topic_name" {
+  type        = string
+  description = "The name of the SNS topic to use for in-hours alarm notifications and clear notifications"
+}
+
+variable "alarm_topic_name_ooh" {
+  type        = string
+  description = "The name of the SNS topic to use for OOH alarm notifications"
+}
+
+# ------------------------------------------------------------------------------
 # NFS Variables
 # ------------------------------------------------------------------------------
 

--- a/groups/ceu-infrastructure/variables.tf
+++ b/groups/ceu-infrastructure/variables.tf
@@ -147,7 +147,7 @@ variable "rds_stop_schedule" {
 # RDS CloudWatch Alarm Variables
 # ------------------------------------------------------------------------------
 variable "alarm_actions_enabled" {
-  type        = string
+  type        = bool
   description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
 }
 


### PR DESCRIPTION
Added module and supporting config to deploy standard RDS CloudWatch alarms
alarm_actions currently disabled to prevent notification spam while alarms settle after creation