### PR TITLE
Allow access from CEU Client CIDRs

### DIFF
--- a/groups/ceu-frontend/alb-internal.tf
+++ b/groups/ceu-frontend/alb-internal.tf
@@ -9,7 +9,7 @@ module "ceu_internal_alb_security_group" {
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = var.fe_nlb_static_addressing ? concat(local.ceu_fe_nlb_cidrs, local.internal_cidrs) : local.internal_cidrs
+  ingress_cidr_blocks = var.fe_nlb_static_addressing ? concat(local.ceu_fe_nlb_cidrs, local.internal_cidrs, local.ceu_fe_client_cidrs) : local.internal_cidrs
 
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
 

--- a/groups/ceu-frontend/data.tf
+++ b/groups/ceu-frontend/data.tf
@@ -94,6 +94,12 @@ data "vault_generic_secret" "ceu_fe_nlb_subnet_mappings" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/nlb_subnet_mappings"
 }
 
+data "vault_generic_secret" "client_cidrs" {
+  count = var.fe_nlb_static_addressing ? 1 : 0
+
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/client_cidrs"
+}
+
 data "aws_acm_certificate" "acm_cert" {
   domain = var.domain_name
 }

--- a/groups/ceu-frontend/locals.tf
+++ b/groups/ceu-frontend/locals.tf
@@ -49,6 +49,8 @@ locals {
     }
    ] : []
 
+  ceu_fe_client_cidrs = var.fe_nlb_static_addressing ? values(data.vault_generic_secret.client_cidrs[0].data) : []
+
   default_tags = {
     Terraform   = "true"
     Application = upper(var.application)


### PR DESCRIPTION
Added data source to obtain client CIDRs from Vault, when `fe_nlb_static_addressing` is true
Added local var to extract CIDRs from the data source, when `fe_nlb_static_addressing` is true
Updated ALB ingress SG rules to include the client CIDRs, when `fe_nlb_static_addressing` is true

⚠️ Ensure Vault data is accurate before merging