### PR TITLE
Per-profile RDS options, disable JVM in staging

### DIFF
--- a/groups/ceu-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -117,6 +117,31 @@ parameter_group_settings = [
     },
 ]
 
+option_group_settings = [
+  {
+    option_name = "JVM"
+  },
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
+
 rds_schedule_enable = true
 rds_start_schedule  = "cron(0 5 * * ? *)"
 rds_stop_schedule   = "cron(0 21 * * ? *)"

--- a/groups/ceu-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -117,6 +117,31 @@ parameter_group_settings = [
     },
 ]
 
+option_group_settings = [
+  {
+    option_name = "JVM"
+  },
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
+
 # ------------------------------------------------------------------------------
 # CEU BEP
 # ------------------------------------------------------------------------------

--- a/groups/ceu-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -24,7 +24,7 @@ rds_backup_window       = "03:00-06:00"
 major_engine_version        = "19"
 engine_version              = "19"
 license_model               = "license-included"
-auto_minor_version_upgrade  = true
+auto_minor_version_upgrade  = false
 
 # RDS Access
 rds_onpremise_access = [
@@ -115,6 +115,28 @@ parameter_group_settings = [
       name  = "workarea_size_policy"
       value = "AUTO"
     },
+]
+
+option_group_settings = [
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
 ]
 
 rds_schedule_enable = true

--- a/groups/ceu-infrastructure/rds.tf
+++ b/groups/ceu-infrastructure/rds.tf
@@ -111,35 +111,13 @@ module "ceu_rds" {
 
   parameters = var.parameter_group_settings
 
-  options = [
+  options = concat([
     {
       option_name                    = "OEM"
       port                           = "5500"
       vpc_security_group_memberships = [module.ceu_rds_security_group.this_security_group_id]
-    },
-    {
-      option_name = "JVM"
-    },
-    {
-      option_name = "SQLT"
-      version     = "2018-07-25.v1"
-      option_settings = [
-        {
-          name  = "LICENSE_PACK"
-          value = "N"
-        },
-      ]
-    },
-    {
-      option_name = "Timezone"
-      option_settings = [
-        {
-          name  = "TIME_ZONE"
-          value = "Europe/London"
-        },
-      ]
-    },
-  ]
+    }
+  ], var.option_group_settings)
 
   timeouts = {
     "create" : "80m",

--- a/groups/ceu-infrastructure/variables.tf
+++ b/groups/ceu-infrastructure/variables.tf
@@ -79,6 +79,11 @@ variable "parameter_group_settings" {
   description = "A list of parameters that will be set in the RDS instance parameter group"
 }
 
+variable "option_group_settings" {
+  type        = any
+  description = "A list of options that will be set in the RDS instance option group"
+}
+
 variable "rds_onpremise_access" {
   type        = list(any)
   description = "A list of cidr ranges that will be allowed access to RDS"


### PR DESCRIPTION
Moved RDS options in to vars to allow for per-profile changes
Updated rds.tf to concatenate standard OEM option with profile options
Removed JVM option and disabeld minor version upgrades in Staging