### PR TITLE
Use Administration Prefix List

### DIFF
--- a/groups/ceu-frontend/alb-internal.tf
+++ b/groups/ceu-frontend/alb-internal.tf
@@ -9,7 +9,8 @@ module "ceu_internal_alb_security_group" {
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = var.fe_nlb_static_addressing ? concat(local.ceu_fe_nlb_cidrs, local.internal_cidrs, local.ceu_fe_client_cidrs) : local.internal_cidrs
+  ingress_cidr_blocks = var.fe_nlb_static_addressing ? concat(local.ceu_fe_nlb_cidrs, local.ceu_fe_client_cidrs) : []
+  ingress_prefix_list_ids = [data.aws_ec2_managed_prefix_list.administration.id]
 
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
 

--- a/groups/ceu-frontend/data.tf
+++ b/groups/ceu-frontend/data.tf
@@ -64,8 +64,8 @@ data "vault_generic_secret" "s3_releases" {
   path = "aws-accounts/shared-services/s3"
 }
 
-data "vault_generic_secret" "internal_cidrs" {
-  path = "aws-accounts/network/internal_cidr_ranges"
+data "aws_ec2_managed_prefix_list" "administration" {
+  name = "administration-cidr-ranges"
 }
 
 data "vault_generic_secret" "kms_keys" {

--- a/groups/ceu-frontend/locals.tf
+++ b/groups/ceu-frontend/locals.tf
@@ -2,7 +2,6 @@
 # Locals
 # ------------------------------------------------------------------------
 locals {
-  internal_cidrs = values(data.vault_generic_secret.internal_cidrs.data)
   s3_releases    = data.vault_generic_secret.s3_releases.data
   ceu_ec2_data   = data.vault_generic_secret.ceu_ec2_data.data
   ceu_fe_data    = data.vault_generic_secret.ceu_fe_data.data_json

--- a/groups/ceu-infrastructure/asg_backend.tf
+++ b/groups/ceu-infrastructure/asg_backend.tf
@@ -9,19 +9,13 @@ module "ceu_bep_asg_security_group" {
   description = "Security group for the ${var.application} backend asg"
   vpc_id      = data.aws_vpc.vpc.id
 
+  ingress_prefix_list_ids = [data.aws_ec2_managed_prefix_list.administration.id]
   ingress_with_cidr_blocks = [
     {
       from_port   = 631
       to_port     = 631
       protocol    = "tcp"
-      description = "CUPS UI Access"
-      cidr_blocks = join(",", local.admin_cidrs)
-    },
-    {
-      from_port   = 631
-      to_port     = 631
-      protocol    = "tcp"
-      description = "Allow health check requests from network load balancer"
+      description = "Allow CUPS access from Administrative CIDRs and load balancer"
       cidr_blocks = join(",", formatlist("%s/32", [for eni in data.aws_network_interface.nlb : eni.private_ip]))
     },
   ]

--- a/groups/ceu-infrastructure/data.tf
+++ b/groups/ceu-infrastructure/data.tf
@@ -36,26 +36,26 @@ data "aws_security_group" "nagios_shared" {
   }
 }
 
-data "aws_security_group" "tuxedo" {
-  filter {
-    name   = "tag:Name"
-    values = ["ceu-frontend-tuxedo-${var.environment}"]
-  }
-}
-
-data "aws_security_group" "ceu_bep" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-ceu-bep-asg*"]
-  }
-}
-
-data "aws_security_group" "chd_bep" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-chd-bep-asg*"]
-  }
-}
+#data "aws_security_group" "tuxedo" {
+#  filter {
+#    name   = "tag:Name"
+#    values = ["ceu-frontend-tuxedo-${var.environment}"]
+#  }
+#}
+#
+#data "aws_security_group" "ceu_bep" {
+#  filter {
+#    name   = "group-name"
+#    values = ["sgr-ceu-bep-asg*"]
+#  }
+#}
+#
+#data "aws_security_group" "chd_bep" {
+#  filter {
+#    name   = "group-name"
+#    values = ["sgr-chd-bep-asg*"]
+#  }
+#}
 
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
@@ -68,6 +68,14 @@ data "aws_iam_role" "rds_enhanced_monitoring" {
 
 data "aws_kms_key" "rds" {
   key_id = "alias/kms-rds"
+}
+
+data "aws_security_group" "rds_ingress" {
+  count = length(var.rds_ingress_groups)
+  filter {
+    name   = "group-name"
+    values = [var.rds_ingress_groups[count.index]]
+  }
 }
 
 data "vault_generic_secret" "account_ids" {
@@ -86,8 +94,8 @@ data "vault_generic_secret" "s3_releases" {
   path = "aws-accounts/shared-services/s3"
 }
 
-data "vault_generic_secret" "internal_cidrs" {
-  path = "aws-accounts/network/internal_cidr_ranges"
+data "aws_ec2_managed_prefix_list" "administration" {
+  name = "administration-cidr-ranges"
 }
 
 data "vault_generic_secret" "kms_keys" {

--- a/groups/ceu-infrastructure/data.tf
+++ b/groups/ceu-infrastructure/data.tf
@@ -36,27 +36,6 @@ data "aws_security_group" "nagios_shared" {
   }
 }
 
-#data "aws_security_group" "tuxedo" {
-#  filter {
-#    name   = "tag:Name"
-#    values = ["ceu-frontend-tuxedo-${var.environment}"]
-#  }
-#}
-#
-#data "aws_security_group" "ceu_bep" {
-#  filter {
-#    name   = "group-name"
-#    values = ["sgr-ceu-bep-asg*"]
-#  }
-#}
-#
-#data "aws_security_group" "chd_bep" {
-#  filter {
-#    name   = "group-name"
-#    values = ["sgr-chd-bep-asg*"]
-#  }
-#}
-
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true

--- a/groups/ceu-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -27,9 +27,10 @@ license_model               = "license-included"
 auto_minor_version_upgrade  = true
 
 # RDS Access
-rds_onpremise_access = [
-  "192.168.90.0/24",
-  "192.168.70.0/24"
+rds_ingress_groups = [
+  "ceu-frontend-tuxedo*",
+  "sgr-ceu-bep-asg*",
+  "sgr-chd-bep-asg*"
 ]
 
 # RDS logging

--- a/groups/ceu-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -27,9 +27,10 @@ license_model               = "license-included"
 auto_minor_version_upgrade  = true
 
 # RDS Access
-rds_onpremise_access = [
-  "192.168.90.0/24",
-  "192.168.70.0/24"
+rds_ingress_groups = [
+  "ceu-frontend-tuxedo*",
+  "sgr-ceu-bep-asg*",
+  "sgr-chd-bep-asg*"
 ]
 
 # RDS logging

--- a/groups/ceu-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -27,9 +27,10 @@ license_model               = "license-included"
 auto_minor_version_upgrade  = false
 
 # RDS Access
-rds_onpremise_access = [
-  "192.168.90.0/24",
-  "192.168.70.0/24"
+rds_ingress_groups = [
+  "ceu-frontend-tuxedo*",
+  "sgr-ceu-bep-asg*",
+  "sgr-chd-bep-asg*"
 ]
 
 # RDS logging

--- a/groups/ceu-infrastructure/rds.tf
+++ b/groups/ceu-infrastructure/rds.tf
@@ -9,16 +9,33 @@ module "ceu_rds_security_group" {
   description = "Security group for the ${var.application} rds database"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = local.rds_ingress_cidrs
-  ingress_rules       = ["oracle-db-tcp"]
+  ingress_prefix_list_ids = [data.aws_ec2_managed_prefix_list.administration.id]
+  ingress_rules           = ["oracle-db-tcp"]
+
+  egress_rules = ["all-all"]
+}
+
+resource "aws_security_group_rule" "oem_rule" {
+  description       = "Oracle Enterprise Manager"
+  from_port         = 5500
+  to_port           = 5500
+  protocol          = "tcp"
+  type              = "ingress"
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.administration.id]
+  security_group_id = module.ceu_rds_security_group.this_security_group_id
+}
+
+module "rds_security_group_services" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 3.0"
+
+  name        = "sgr-${var.application}-rds-002"
+  description = "Security group for the ${var.application} rds database"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  ingress_rules                         = ["oracle-db-tcp"]
+  ingress_with_source_security_group_id = local.rds_ingress_from_services
   ingress_with_cidr_blocks = [
-    {
-      from_port   = 5500
-      to_port     = 5500
-      protocol    = "tcp"
-      description = "Oracle Enterprise Manager"
-      cidr_blocks = join(",", local.rds_ingress_cidrs)
-    },
     {
       from_port   = "1521"
       to_port     = "1521"
@@ -26,29 +43,6 @@ module "ceu_rds_security_group" {
       description = "Frontend CEU"
       cidr_blocks = join(",", local.ceu_fe_subnet_cidrs)
     }
-  ]
-  ingress_with_source_security_group_id = [
-    {
-      from_port                = "1521"
-      to_port                  = "1521"
-      protocol                 = "tcp"
-      description              = "Frontend Tuxedo"
-      source_security_group_id = data.aws_security_group.tuxedo.id
-    },
-    {
-      from_port                = "1521"
-      to_port                  = "1521"
-      protocol                 = "tcp"
-      description              = "Backend CEU"
-      source_security_group_id = data.aws_security_group.ceu_bep.id
-    },
-    {
-      from_port                = "1521"
-      to_port                  = "1521"
-      protocol                 = "tcp"
-      description              = "Backend CHD"
-      source_security_group_id = data.aws_security_group.chd_bep.id
-    },
   ]
 
   egress_rules = ["all-all"]

--- a/groups/ceu-infrastructure/variables.tf
+++ b/groups/ceu-infrastructure/variables.tf
@@ -84,9 +84,9 @@ variable "option_group_settings" {
   description = "A list of options that will be set in the RDS instance option group"
 }
 
-variable "rds_onpremise_access" {
-  type        = list(any)
-  description = "A list of cidr ranges that will be allowed access to RDS"
+variable "rds_ingress_groups" {
+  type        = list(string)
+  description = "A list of security group name patterns that will be allowed access to RDS"
   default     = []
 }
 


### PR DESCRIPTION
Updates security group config to utilise a Managed Prefix List to define administrative access, rather that pulling data from vault. This will allow for safer and easier future updates to administrative access.

## ceu-infrastructure
Replaced `internal_cidrs` vault lookup with managed prefix list lookup
Removed deprecated local var
Added data lookup for RDS access based on security group pattern
Restructured RDS security group to prevent unwanted duplication of prefix list
* Added prefix list
* Added new rule resource for OEM access
* Added new security group specific for service access

Added prefix list to ASG security group
Added new supporting variable
Removed deprecated profile vars

## ceu-frontend
Replaced `internal_cidrs` vault lookup with managed prefix list lookup
Removed deprecated local var
Updated ALB security group to use prefix list