### PR TITLE
Permit access to RDS from OLTP

### DIFF
--- a/groups/ceu-infrastructure/data.tf
+++ b/groups/ceu-infrastructure/data.tf
@@ -57,6 +57,15 @@ data "aws_security_group" "chd_bep" {
   }
 }
 
+data "aws_security_group" "rds_ingress" {
+  for_each = toset(var.rds_ingress_groups)
+
+  filter {
+    name   = "group-name"
+    values = [each.value]
+  }
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true

--- a/groups/ceu-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -27,6 +27,10 @@ license_model               = "license-included"
 auto_minor_version_upgrade  = false
 
 # RDS Access
+rds_ingress_groups = [
+  "sgr-chips-oltp-db-ec2-*"
+]
+
 rds_onpremise_access = [
   "192.168.90.0/24",
   "192.168.70.0/24"

--- a/groups/ceu-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -27,6 +27,10 @@ license_model               = "license-included"
 auto_minor_version_upgrade  = false
 
 # RDS Access
+rds_ingress_groups = [
+  "sgr-chips-oltp-db-ec2-*"
+]
+
 rds_onpremise_access = [
   "192.168.90.0/24",
   "192.168.70.0/24"

--- a/groups/ceu-infrastructure/rds.tf
+++ b/groups/ceu-infrastructure/rds.tf
@@ -65,6 +65,18 @@ resource "aws_security_group_rule" "dba_dev_ingress" {
   security_group_id = module.ceu_rds_security_group.this_security_group_id
 }
 
+resource "aws_security_group_rule" "oracle_access_sgs" {
+  for_each = data.aws_security_group.rds_ingress
+
+  type                     = "ingress"
+  description              = "Oracle access from ${each.value.id}"
+  from_port                = 1521
+  to_port                  = 1522
+  protocol                 = "tcp"
+  source_security_group_id = each.value.id
+  security_group_id        = module.ceu_rds_security_group.this_security_group_id
+}
+
 # ------------------------------------------------------------------------------
 # RDS ceu
 # ------------------------------------------------------------------------------

--- a/groups/ceu-infrastructure/variables.tf
+++ b/groups/ceu-infrastructure/variables.tf
@@ -84,6 +84,12 @@ variable "option_group_settings" {
   description = "A list of options that will be set in the RDS instance option group"
 }
 
+variable "rds_ingress_groups" {
+  type        = list(string)
+  description = "A list of security group name patterns that will be allowed access to RDS"
+  default     = []
+}
+
 variable "rds_onpremise_access" {
   type        = list(any)
   description = "A list of cidr ranges that will be allowed access to RDS"


### PR DESCRIPTION
Added new `rds_ingress_group` input var
- will be used as part of a refactor in the future

Adds data source to lookup security group names
Adds resource to define security group rules to permit ingress from the specified security groups