### PR TITLE
Permit Concourse access to RDS database

### DIFF
--- a/groups/ceu-infrastructure/data.tf
+++ b/groups/ceu-infrastructure/data.tf
@@ -123,6 +123,10 @@ data "vault_generic_secret" "ceu_fe_outputs" {
   path = "applications/${var.environment == "live" ? "pci-services-${var.aws_region}" : var.aws_profile}/${var.application}/ceu-fe-outputs"
 }
 
+data "aws_ec2_managed_prefix_list" "concourse" {
+  name = "shared-services-management-cidrs"
+}
+
 #-----------------
 # CEU Backend Data
 #-----------------

--- a/groups/ceu-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/ceu-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -26,6 +26,8 @@ engine_version              = "19"
 license_model               = "license-included"
 auto_minor_version_upgrade  = true
 
+rds_concourse_access = true
+
 # RDS Access
 rds_onpremise_access = [
   "192.168.90.0/24",

--- a/groups/ceu-infrastructure/rds.tf
+++ b/groups/ceu-infrastructure/rds.tf
@@ -77,6 +77,18 @@ resource "aws_security_group_rule" "oracle_access_sgs" {
   security_group_id        = module.ceu_rds_security_group.this_security_group_id
 }
 
+resource "aws_security_group_rule" "concourse_ingress" {
+  count = var.rds_concourse_access ? 1 : 0
+
+  description       = "Ingress from Concourse"
+  type              = "ingress"
+  from_port         = 1521
+  to_port           = 1521
+  protocol          = "tcp"
+  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.concourse.id]
+  security_group_id = module.ceu_rds_security_group.this_security_group_id
+}
+
 # ------------------------------------------------------------------------------
 # RDS ceu
 # ------------------------------------------------------------------------------

--- a/groups/ceu-infrastructure/variables.tf
+++ b/groups/ceu-infrastructure/variables.tf
@@ -90,6 +90,12 @@ variable "rds_ingress_groups" {
   default     = []
 }
 
+variable "rds_concourse_access" {
+  type        = bool
+  description = "A boolean value indicating whether to allow Concourse ingress to the RDS database"
+  default     = false
+}
+
 variable "rds_onpremise_access" {
   type        = list(any)
   description = "A list of cidr ranges that will be allowed access to RDS"


### PR DESCRIPTION
This change allows Concourse pipelines to access the RDS database in order to allow database refreshes as part of the migration of [chl-database](https://github.com/companieshouse/chl-database) to Concourse.