### PR TITLE
disable-tenable-cwp-scan

### DIFF
--- a/groups/ceu-frontend/asg-frontend.tf
+++ b/groups/ceu-frontend/asg-frontend.tf
@@ -111,7 +111,9 @@ module "fe_asg" {
   tags_as_map = merge(
     local.default_tags,
     {
-      ServiceTeam = "${upper(var.application)}-FE-Support"
+      ServiceTeam               = "${upper(var.application)}-FE-Support"
+      tenable-cwp-scan-disabled = "true"
+      Repository                = "ceu-terraform"
     }
   )
 

--- a/groups/ceu-infrastructure/asg-backend.tf
+++ b/groups/ceu-infrastructure/asg-backend.tf
@@ -124,8 +124,10 @@ module "bep_asg" {
   tags_as_map = merge(
     local.default_tags,
     {
-      Name        = "${var.application}-bep"
-      ServiceTeam = "${upper(var.application)}-BEP-Support"
+      Name                      = "${var.application}-bep"
+      ServiceTeam               = "${upper(var.application)}-BEP-Support"
+      tenable-cwp-scan-disabled = "true"
+      Repository                = "ceu-terraform"
     }
   )
 }


### PR DESCRIPTION
This is for [DVOP-4517](https://companieshouse.atlassian.net/browse/DVOP-4517)

There is an issue where workload scanning cannot run on certain instances either due to licensing restrictions or the workload doesn't support the scanner.

Once they have been excluded, inspector will be ingested into tenable ([DVOP-4853](https://companieshouse.atlassian.net/browse/DVOP-4853)) instead to restore the data and circumvent the workload scanning issues

[DVOP-4517]: https://companieshouse.atlassian.net/browse/DVOP-4517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DVOP-4853]: https://companieshouse.atlassian.net/browse/DVOP-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ